### PR TITLE
Create landing zone directory on startup

### DIFF
--- a/src/main/java/com/captech/alfred/Startup.java
+++ b/src/main/java/com/captech/alfred/Startup.java
@@ -102,6 +102,7 @@ public class Startup implements CommandLineRunner {
             Files.createDirectories(Paths.get(textProperties.getFullCurrentRefined()));
             Files.createDirectories(Paths.get(textProperties.getFullCurrentSandbox()));
             Files.createDirectories(Paths.get(textProperties.getFullVersionedSandbox()));
+            Files.createDirectories(Paths.get(textProperties.getLandingZone()));
         }
         if (dataUserConn instanceof TextUsers) {
             Files.createDirectories(Paths.get(userProperties.getTextfullAuthPath()));


### PR DESCRIPTION
This is to fix an issue where the landing zone directory isn't created prior to attempting to upload a text file.