### PR TITLE
Potential fix for code scanning alert no. 8: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/com/captech/alfred/dataConnections/textFiles/TextFileDatastoreService.java
+++ b/src/main/java/com/captech/alfred/dataConnections/textFiles/TextFileDatastoreService.java
@@ -47,6 +47,12 @@ import java.util.UUID;
 
 @Service
 @EnableConfigurationProperties(TextFileProperties.class)
+
+private void validateGuid(String guid) {
+    if (guid.contains("..") || guid.contains("/") || guid.contains("\\")) {
+        throw new IllegalArgumentException("Invalid guid");
+    }
+}
 public class TextFileDatastoreService extends DataStoreService {
 
     private static final Logger logger = LoggerFactory.getLogger(TextFileDatastoreService.class);
@@ -291,6 +297,7 @@ public class TextFileDatastoreService extends DataStoreService {
     @Override
     public List<InstanceLog> getInstanceLog(final String guid) {
 
+        validateGuid(guid);
         List<InstanceLog> logs = new ArrayList<>();
         FileReader fr = null;
         File dir = new File(Paths.get(textFileProperties.getLogLocation()).toString());
@@ -334,6 +341,7 @@ public class TextFileDatastoreService extends DataStoreService {
 
     @Override
     public Guid writeInstanceLog(InstanceLog log, String guid) {
+        validateGuid(guid);
         UUID guidUUID = UUID.randomUUID();
         if (guid == null) {
             guid = guidUUID.toString();

--- a/src/main/java/com/captech/alfred/dataConnections/textFiles/TextFileDatastoreService.java
+++ b/src/main/java/com/captech/alfred/dataConnections/textFiles/TextFileDatastoreService.java
@@ -53,6 +53,12 @@ private void validateGuid(String guid) {
         throw new IllegalArgumentException("Invalid guid");
     }
 }
+
+private void validateKey(String key) {
+        if (key.contains("..")) {
+            throw new IllegalArgumentException("Invalid key");
+        }
+    }
 public class TextFileDatastoreService extends DataStoreService {
 
     private static final Logger logger = LoggerFactory.getLogger(TextFileDatastoreService.class);
@@ -90,6 +96,7 @@ public class TextFileDatastoreService extends DataStoreService {
     }
 
     public Template getMetadata(String key) {
+        validateKey(key);
         Template template = getCurrentMetadata(key);
         if (template != null) {
             return template;


### PR DESCRIPTION
Potential fix for [https://github.com/captechconsulting/alfred/security/code-scanning/8](https://github.com/captechconsulting/alfred/security/code-scanning/8)

To fix the problem, we need to validate the `guid` parameter before using it to construct file paths. We can ensure that the `guid` does not contain any path separators or parent directory references. This can be done by checking for the presence of "..", "/", or "\\" in the `guid` string and throwing an exception if any are found.

The best way to fix the problem without changing existing functionality is to add a validation method in the `TextFileDatastoreService` class and call this method before using the `guid` parameter to construct file paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
